### PR TITLE
Corrected packed length calculation.

### DIFF
--- a/lib/artnet-client.js
+++ b/lib/artnet-client.js
@@ -18,7 +18,7 @@ exports.createClient = function(host, port, universe) {
 
 ArtNetClient.prototype.send = function(data) {
 	// Calcualte the length
-	var length_upper = Math.floor(data.length / 256) || 2;
+	var length_upper = Math.floor(data.length / 256);
 	var length_lower = data.length % 256;
 
 	var data = this.HEADER.concat(this.SEQUENCE).concat(this.PHYSICAL).concat(this.UNIVERSE).concat([length_upper, length_lower]).concat(data);


### PR DESCRIPTION
When packet was less than 256 values, upper byte of length was set to 2, causing the length to be 512 + actual length.